### PR TITLE
RN-Images can be deleted from Index page

### DIFF
--- a/app/assets/stylesheets/images.scss
+++ b/app/assets/stylesheets/images.scss
@@ -35,6 +35,7 @@ body {
 
 img {
   max-width: 400px;
+  display: list-item;
 }
 
 .image-list, .tags  {
@@ -43,7 +44,20 @@ img {
 
 .image-display {
   display: inline-table;
-  padding: 0px 10px 10px 0px;
+  padding: 0px 10px 25px 0px;
+}
+
+.tag-link {
+  display: inline-block;
+}
+
+.delete-link {
+  float: right;
+  color: $error-color
+}
+
+.alert-deleted {
+  background: $button-color
 }
 
 label {

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -34,4 +34,11 @@ class ImagesController < ApplicationController
                 Image.all
               end
   end
+
+  def destroy
+    @image = Image.find(params[:id])
+    @image.destroy
+    flash[:deleted] = 'Image has been deleted successfully'
+    redirect_to images_path
+  end
 end

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -9,10 +9,14 @@
       <%= image_tag image.url %>
       <% if image.tag_list.present? %>
         <br>
-        <p><% image.tag_list.each do |tag| %>
+        <span>Tags: </span>
+        <p class='tag-link'><% image.tag_list.each do |tag| %>
             <%= link_to tag, tagged_path(tag: tag) %>
           <% end %></p>
       <% end %>
+      <%= link_to 'Destroy', image_path(image), class: 'delete-link',
+                  method: :delete,
+                  data: { confirm: 'Are you sure you want to delete this image?' } %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'images#index'
-  resources :images, only: %i[new create show index]
+  resources :images, only: %i[new create show index destroy]
   get '/tagged', to: 'images#tagged', as: :tagged
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -93,7 +93,8 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select '.image-display' do |images|
       images.each do |image|
         assert_select image, 'img', count: 1
-        assert_select image, 'a', count: tags.split(/\s*,\s*/).count
+        assert_select image, '.tag-link a', count: tags.split(/\s*,\s*/).count
+        assert_select image, '.delete-link', count: 1
       end
     end
   end
@@ -106,7 +107,8 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select '.image-display' do |images|
       images.each do |image|
         assert_select image, 'img', count: 1
-        assert_select image, 'a', count: 0
+        assert_select image, '.tag-link a', count: 0
+        assert_select image, '.delete-link', count: 1
       end
     end
   end
@@ -129,5 +131,18 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'p', 'No images found for the specified tag!'
     assert_select '.image-display', count: 0
     assert_select "a[href='#{images_path}']", count: 1
+  end
+
+  test 'Destroy ' do
+    Image.create!(url: 'https://tinyurl.com/123')
+    Image.create!(url: 'https://tinyurl.com/456')
+    get images_path
+    assert_select '.image-display' do |images|
+      images.each do |image|
+        assert_select image, '.delete-link', count: 1
+        assert_select image, 'a[data-method="delete"]', count: 1
+        assert_select image, 'a[data-confirm="Are you sure you want to delete this image?"]', count: 1
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #6 (Partially -  only deletion change is implemented. Will update the same PR for the Flow test changes)